### PR TITLE
fix crash when handling ^e on long lines

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -107,7 +107,7 @@ func (e *Edit) KeyHandler(ev termbox.Event) bool {
 	case termbox.KeyCtrlE, termbox.KeyEnd:
 		if len(e.display) < e.trueW-1 {
 			// no need to call display
-			e.cx = e.trueX + len(e.display)
+			e.cx = e.trueX + len(e.display) - e.at
 			setCursor(e.cx, e.cy)
 			return true
 		}


### PR DESCRIPTION
we need to include e.at in the calculation of the cursor when handling
^e on long lines. doing otherwise results in an out of bounds error
when calculating inString for the next keystroke. this fixes https://github.com/companyzero/ttk/issues/11.