### PR TITLE
fix crash on resize

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -291,6 +291,7 @@ func (e *Edit) Resize() {
 			// end of text
 			if len(e.display) < e.trueW-1 {
 				e.cx = e.trueX + len(e.display)
+				e.at = 0
 			} else {
 				e.cx = e.trueX + e.trueW - 1
 				e.at = len(e.display) - e.trueW + 1


### PR DESCRIPTION
if the cursor is at the end of the input text when resizing, and the
new width of the window allows us to represent the complete input,
then we need to reset e.at. this fixes #14.