### PR TITLE
update l.at when resizing a list widget

### DIFF
--- a/list.go
+++ b/list.go
@@ -155,7 +155,7 @@ func (l *List) Resize() {
 	}
 
 	// check if we need to update l.at
-	if l.at != 0 && l.at + l.trueH >= len(l.content) {
+	if l.at != 0 && l.at+l.trueH >= len(l.content) {
 		l.at = len(l.content) - l.trueH
 		if l.at < 0 {
 			l.at = 0

--- a/list.go
+++ b/list.go
@@ -153,6 +153,14 @@ func (l *List) Resize() {
 	if l.height < 1 {
 		l.trueH = l.w.y + l.height - 1
 	}
+
+	// check if we need to update l.at
+	if l.at != 0 && l.at + l.trueH >= len(l.content) {
+		l.at = len(l.content) - l.trueH
+		if l.at < 0 {
+			l.at = 0
+		}
+	}
 }
 
 // AddList is a convenience function to add a new list to a window.  It wraps


### PR DESCRIPTION
if the height of a list widget increases, then we need to shrink l.at
accordingly, or we risk an out-of-bounds memory access when rendering
the widget in Display(). this fixes #9.